### PR TITLE
adds options collector service and serviceMonitor for additional metrics

### DIFF
--- a/helm/jaeger-operator-app/README.md
+++ b/helm/jaeger-operator-app/README.md
@@ -48,24 +48,34 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the jaeger-operator chart and their default values.
 
-| Parameter               | Description                                                                                                 | Default                         |
-| :---------------------- | :---------------------------------------------------------------------------------------------------------- | :------------------------------ |
-| `image.repository`      | Controller container image repository                                                                       | `jaegertracing/jaeger-operator` |
-| `image.tag`             | Controller container image tag                                                                              | `1.18.0`                        |
-| `image.pullPolicy`      | Controller container image pull policy                                                                      | `IfNotPresent`                  |
-| `jaeger.create`         | Jaeger instance will be created                                                                             | `false`                         |
-| `jaeger.spec`           | Jaeger instance specification                                                                               | `{}`                            |
-| `crd.install`           | CustomResourceDefinition will be installed                                                                  | `true`                          |
-| `rbac.create`           | All required roles and rolebindings will be created                                                         | `true`                          |
-| `serviceAccount.create` | Service account to use                                                                                      | `true`                          |
-| `rbac.pspEnabled`       | Pod security policy for pod will be created and included in rbac role                                       | `false`                         |
-| `rbac.clusterRole`      | ClusterRole will be used by operator ServiceAccount                                                         | `false`                         |
-| `serviceAccount.name`   | Service account name to use. If not set and create is true, a name is generated using the fullname template | `nil`                           |
-| `resources`             | K8s pod resources                                                                                           | `None`                          |
-| `nodeSelector`          | Node labels for pod assignment                                                                              | `{}`                            |
-| `tolerations`           | Toleration labels for pod assignment                                                                        | `[]`                            |
-| `affinity`              | Affinity settings for pod assignment                                                                        | `{}`                            |
-| `securityContext`       | Security context for pod                                                                                    | `{}`                            |
+| Parameter                                    | Description                                                                                                 | Default                         |
+| :------------------------------------------- | :---------------------------------------------------------------------------------------------------------- | :------------------------------ |
+| `image.repository`                           | Controller container image repository                                                                       | `jaegertracing/jaeger-operator` |
+| `image.tag`                                  | Controller container image tag                                                                              | `1.18.0`                        |
+| `image.pullPolicy`                           | Controller container image pull policy                                                                      | `IfNotPresent`                  |
+| `jaeger.create`                              | Jaeger instance will be created                                                                             | `false`                         |
+| `jaeger.spec`                                | Jaeger instance specification                                                                               | `{}`                            |
+| `crd.install`                                | CustomResourceDefinition will be installed                                                                  | `true`                          |
+| `rbac.create`                                | All required roles and rolebindings will be created                                                         | `true`                          |
+| `serviceAccount.create`                      | Service account to use                                                                                      | `true`                          |
+| `rbac.pspEnabled`                            | Pod security policy for pod will be created and included in rbac role                                       | `false`                         |
+| `rbac.clusterRole`                           | ClusterRole will be used by operator ServiceAccount                                                         | `false`                         |
+| `serviceAccount.name`                        | Service account name to use. If not set and create is true, a name is generated using the fullname template | `nil`                           |
+| `resources`                                  | K8s pod resources                                                                                           | `None`                          |
+| `nodeSelector`                               | Node labels for pod assignment                                                                              | `{}`                            |
+| `tolerations`                                | Toleration labels for pod assignment                                                                        | `[]`                            |
+| `affinity`                                   | Affinity settings for pod assignment                                                                        | `{}`                            |
+| `securityContext`                            | Security context for pod                                                                                    | `{}`                            |
+| `collector.service.enabled`                  | creates the collector service on admin-http port 14269                                                      | `false`                       |
+| `collector.serviceMonitor.enabled`           | creates the corresponding service monitor for collector metrics                                             | `false`                       |
+| `collector.serviceMonitor.additionalLabels`  | additional labels for collector service monitor                                                             | `{}`                            |
+| `collector.serviceMonitor.interval`          | Interval at which metrics should be scraped                                                                 | `10s`                           |
+| `collector.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                                     | `10s`                           |
+| `collector.serviceMonitor.scheme`            | Scheme to use for scraping                                                                                  | `http`                        |
+| `collector.serviceMonitor.relabelings`       | Relabel configuration for the metrics                                                                       | `[]`                            |
+| `collector.serviceMonitor.targetLabels`      | Set of labels to transfer on the Kubernetes Service onto the target                                         | `[]`                            |
+| `collector.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion                                                   | `[]`                            |
+| `collector.serviceMonitor.sampleLimit`       | Number of samples that will fail the scrape if exceeded                                                     | `[]`                            |
 
 Specify each parameter you'd like to override using a YAML file as described above in the [installation](#installing-the-chart) section.
 

--- a/helm/jaeger-operator-app/templates/collector-service-monitor.yaml
+++ b/helm/jaeger-operator-app/templates/collector-service-monitor.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.collector.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "jaeger-operator.fullname" . }}-admin
+  labels:
+{{ include "jaeger-operator.labels" . | indent 4 }}
+{{- if .Values.collector.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.collector.serviceMonitor.additionalLabels | indent 4 }}
+{{- end }}
+spec:
+  endpoints:
+  - port: admin-http
+    interval: {{ .Values.collector.serviceMonitor.interval }}
+    {{- if .Values.collector.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.collector.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    scheme: {{ .Values.collector.serviceMonitor.scheme }}
+    {{- if .Values.collector.serviceMonitor.relabelings }}
+    relabelings:
+    {{ toYaml .Values.collector.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+    {{- if .Values.collector.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{ toYaml .Values.collector.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
+  selector:
+    matchLabels:
+    {{ include "jaeger-operator.labels" . | indent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- if .Values.collector.serviceMonitor.targetLabels }}
+  targetLabels:
+{{- range .Values.collector.serviceMonitor.targetLabels }}
+    - {{ . }}
+{{- end }}
+{{- end }}
+  sampleLimit: {{ .Values.collector.serviceMonitor.sampleLimit }}
+{{- end }}

--- a/helm/jaeger-operator-app/templates/collector-service.yaml
+++ b/helm/jaeger-operator-app/templates/collector-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.collector.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "jaeger-operator.fullname" . }}-admin
+  labels:
+{{ include "jaeger-operator.labels" . | indent 4 }} 
+spec:
+  ports:
+  - name: admin-http
+    port: 14269
+    protocol: TCP
+    targetPort: 14269
+  selector:
+    app.kubernetes.io/name: {{ include "jaeger-operator.fullname" . }}-jaeger
+  type: ClusterIP
+{{- end -}}

--- a/helm/jaeger-operator-app/values.yaml
+++ b/helm/jaeger-operator-app/values.yaml
@@ -61,7 +61,7 @@ collector:
     targetLabels: []
     metricRelabelings: []
     sampleLimit: 0
-    
+
 nodeSelector: {}
 
 tolerations: []

--- a/helm/jaeger-operator-app/values.yaml
+++ b/helm/jaeger-operator-app/values.yaml
@@ -47,6 +47,21 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+# exposes a service and corresponding service monitor for additional metrics via admin-http port 14269
+collector:
+  service:
+    enabled: false
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
+    interval: 10s
+    scrapeTimeout: 10s
+    scheme: http
+    relabelings: []
+    targetLabels: []
+    metricRelabelings: []
+    sampleLimit: 0
+    
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
- adds option for collector service on admin-http port 14269
- adds options for corresponding collector service monitor

Note: selector label for service is set as `app.kubernetes.io/name: {{ include "jaeger-operator.fullname" . }}-jaeger`

This was based on the fact that when looking at the relevant deployment resource already deployed on a GS cluster e.g:

`kubectl get deploy jaeger-jaeger-operator-app-jaeger -n jaeger -o yaml`

The following pod labels are set (by operator): 
```labels:
        app: jaeger
        app.kubernetes.io/component: all-in-one
        app.kubernetes.io/instance: jaeger-jaeger-operator-app-jaeger
        app.kubernetes.io/managed-by: jaeger-operator
        app.kubernetes.io/name: jaeger-jaeger-operator-app-jaeger
        app.kubernetes.io/part-of: jaeger
```

so the suffix `-jaeger` had to be added in selector label of the service, in order to have a match. Also hopefully, the prefix `jaeger-` will be there with the `{{ include "jaeger-operator.fullname" . }}` 
