### PR TITLE
collector-service metrics fix to support production mode.

### DIFF
--- a/helm/jaeger-operator-app/templates/collector-service.yaml
+++ b/helm/jaeger-operator-app/templates/collector-service.yaml
@@ -12,6 +12,6 @@ spec:
     protocol: TCP
     targetPort: 14269
   selector:
-    app.kubernetes.io/name: {{ include "jaeger-operator.fullname" . }}-jaeger
+    app.kubernetes.io/instance: {{ include "jaeger-operator.fullname" . }}-jaeger
   type: ClusterIP
 {{- end -}}


### PR DESCRIPTION
when deploying Jaeger in production mode, there is no jaeger pod running (as in all-in-one mode), but separate collector and query pods. so the value of previous `app.kubernetes.io/name` changes and is no longer valid for production mode. It seems though that  `app.kubernetes.io/instance` is consistent in both modes. hence this fix.